### PR TITLE
fix: repeated nested keys

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -186,7 +186,7 @@ export function parse(input: string, options?: UserParseOptions): ParsedQuery {
             (currentValue as unknown[]).push(newValue);
           } else {
             if (shouldDoNesting) {
-              dset(result, newKey as string, [currentValue, newValue]);
+              dset(result, dlvKey, [currentValue, newValue]);
             } else {
               result[newKey] = [currentValue, newValue];
             }

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -89,6 +89,11 @@ const testCases: TestCase[] = [
     output: {foo: ['x', 'y']},
     options: {arrayRepeat: true, arrayRepeatSyntax: 'repeat'}
   },
+  {
+    input: 'foo.bar=x&foo.bar=y',
+    output: {foo: {bar: ['x', 'y']}},
+    options: {arrayRepeat: true, arrayRepeatSyntax: 'repeat'}
+  },
 
   // Nesting syntax: index
   {


### PR DESCRIPTION
Repeating nested keys when `arrayRepeat` is `true` should result in an array of the multiple values. This fixes the functionality.