### PR TITLE
feat: rework nesting logic

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -16,8 +16,8 @@ export type NestingSyntax =
 export const CONTINUE = Symbol('continue');
 
 export type DeserializeValueFunction = (
-  key: string,
-  value: string
+  value: string,
+  key: string
 ) => unknown | typeof CONTINUE;
 
 export type DeserializeKeyFunction = (
@@ -47,6 +47,6 @@ export interface ParseOptions {
   delimiter: string | number;
 
   // Custom deserializers
-  valueDeserializer?: DeserializeValueFunction;
-  keyDeserializer?: DeserializeKeyFunction;
+  valueDeserializer: DeserializeValueFunction;
+  keyDeserializer: DeserializeKeyFunction;
 }

--- a/src/string-util.ts
+++ b/src/string-util.ts
@@ -1,10 +1,15 @@
 export function splitByIndexPattern(input: string): string[] {
+  const firstIndex = input.indexOf('[');
+  if (firstIndex === -1) {
+    return [input];
+  }
+
   const result: string[] = [];
   const inputLength = input.length;
   let offset = 0;
   let open = false;
 
-  for (let i = 0; i < inputLength; i++) {
+  for (let i = firstIndex; i < inputLength; i++) {
     const chr = input[i];
     if (chr === '[' && !open) {
       if (offset !== i) {

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -194,7 +194,7 @@ const testCases: TestCase[] = [
     input: 'foo=three&bar=four',
     output: {foo: 3, bar: 'four'},
     options: {
-      valueDeserializer: (_key, value) => {
+      valueDeserializer: (value) => {
         if (value === 'three') {
           return 3;
         }


### PR DESCRIPTION
Reworks the nesting logic slightly to be faster.

We now detect some array syntax up front during character iteration, and only deeply read/set values if the key contains nesting syntax.