### PR TITLE
feat: rename nested to nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The default options are as follows:
 
 ```ts
 {
-  nested: true,
+  nesting: true,
   nestingSyntax: 'dot',
   arrayRepeat: false,
   arrayRepeatSyntax: 'repeat',
@@ -74,14 +74,14 @@ The default options are as follows:
 }
 ```
 
-### `nested`
+### `nesting`
 
 When true, nested objects are supported.
 
 For example, when parsing:
 
 ```ts
-parse('foo.bar=baz', {nested: true});
+parse('foo.bar=baz', {nesting: true});
 
 // {foo: {bar: 'baz'}}
 ```
@@ -89,7 +89,7 @@ parse('foo.bar=baz', {nested: true});
 When stringifying:
 
 ```ts
-stringify({foo: {bar: 'baz'}}, {nested: true});
+stringify({foo: {bar: 'baz'}}, {nesting: true});
 
 // foo.bar=baz
 ```
@@ -97,10 +97,10 @@ stringify({foo: {bar: 'baz'}}, {nested: true});
 This also results in arrays being supported:
 
 ```ts
-parse('foo.0=bar', {nested: true});
+parse('foo.0=bar', {nesting: true});
 // {foo: ['bar']}
 
-stringify({foo: ['bar']}, {nested: true});
+stringify({foo: ['bar']}, {nesting: true});
 // foo.0=bar
 ```
 

--- a/bench/parse.js
+++ b/bench/parse.js
@@ -9,7 +9,7 @@ const suites = [
     inputs: ['foo=a&bar=b&baz=c'],
     options: {
       qs: {allowDots: false},
-      pico: {nested: false}
+      pico: {nesting: false}
     }
   },
   {
@@ -17,7 +17,7 @@ const suites = [
     inputs: ['foo.bar.x=303&foo.bar.y=808'],
     options: {
       qs: {allowDots: true},
-      pico: {nested: true}
+      pico: {nesting: true}
     }
   },
   {
@@ -25,7 +25,7 @@ const suites = [
     inputs: ['foo[bar][x]=303&foo[bar][y]=808'],
     options: {
       qs: {allowDots: false},
-      pico: {nested: true, nestingSyntax: 'index'}
+      pico: {nesting: true, nestingSyntax: 'index'}
     }
   },
   {
@@ -33,7 +33,7 @@ const suites = [
     inputs: ['foo=a;bar=b;baz=c'],
     options: {
       qs: {delimiter: ';'},
-      pico: {nested: false, delimiter: ';'}
+      pico: {nesting: false, delimiter: ';'}
     }
   },
   {

--- a/bench/stringify.js
+++ b/bench/stringify.js
@@ -9,7 +9,7 @@ const suites = [
     inputs: [{foo: 'x', bar: 'y', baz: 'z'}],
     options: {
       qs: {allowDots: false},
-      pico: {nested: false}
+      pico: {nesting: false}
     }
   },
   {
@@ -27,7 +27,7 @@ const suites = [
     ],
     options: {
       qs: {allowDots: true},
-      pico: {nested: true}
+      pico: {nesting: true}
     }
   },
   {
@@ -45,7 +45,7 @@ const suites = [
     ],
     options: {
       qs: {allowDots: false},
-      pico: {nested: true, nestingSyntax: 'index'}
+      pico: {nesting: true, nestingSyntax: 'index'}
     }
   },
   {
@@ -53,7 +53,7 @@ const suites = [
     inputs: [{foo: 'a', bar: 'b', baz: 'c'}],
     options: {
       qs: {delimiter: ';'},
-      pico: {nested: false, delimiter: ';'}
+      pico: {nesting: false, delimiter: ';'}
     }
   },
   {

--- a/src/object-util.ts
+++ b/src/object-util.ts
@@ -31,7 +31,7 @@ function walkNestedValues(
     nestingSyntax = defaultOptions.nestingSyntax,
     arrayRepeat = defaultOptions.arrayRepeat,
     arrayRepeatSyntax = defaultOptions.arrayRepeatSyntax,
-    nested = defaultOptions.nested
+    nesting = defaultOptions.nesting
   } = options;
 
   if (depth > MAX_DEPTH) {
@@ -64,7 +64,7 @@ function walkNestedValues(
     if (
       typeof value === 'object' &&
       value !== null &&
-      (nested || (arrayRepeat && probableArray))
+      (nesting || (arrayRepeat && probableArray))
     ) {
       walkNestedValues(
         value as Record<PropertyKey, unknown>,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -42,7 +42,7 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
     valueDeserializer = defaultOptions.valueDeserializer,
     keyDeserializer = defaultOptions.keyDeserializer,
     arrayRepeatSyntax = defaultOptions.arrayRepeatSyntax,
-    nested = defaultOptions.nested,
+    nesting = defaultOptions.nesting,
     arrayRepeat = defaultOptions.arrayRepeat,
     nestingSyntax = defaultOptions.nestingSyntax,
     delimiter = defaultOptions.delimiter
@@ -118,7 +118,7 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
         const newKey = keyDeserializer(key);
         let dlvKey;
 
-        if (typeof newKey === 'string' && nested) {
+        if (typeof newKey === 'string' && nesting) {
           if (nestingSyntax === 'index') {
             dlvKey = splitByIndexPattern(newKey);
           } else {
@@ -127,10 +127,10 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
         }
 
         const currentValue =
-          nested && dlvKey ? getDeepValue(result, dlvKey) : result[newKey];
+          nesting && dlvKey ? getDeepValue(result, dlvKey) : result[newKey];
 
         if (currentValue === undefined || !arrayRepeat) {
-          if (nested && dlvKey) {
+          if (nesting && dlvKey) {
             dset(result, dlvKey, newValue);
           } else {
             result[newKey] = newValue;
@@ -140,7 +140,7 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
           if ((currentValue as unknown[]).pop) {
             (currentValue as unknown[]).push(newValue);
           } else {
-            if (nested && dlvKey) {
+            if (nesting && dlvKey) {
               dset(result, dlvKey, [currentValue, newValue]);
             } else {
               result[newKey] = [currentValue, newValue];

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -10,19 +10,14 @@ export type NestingSyntax =
   // `foo[bar]`
   | 'index';
 
-export type DeserializeValueFunction = (
-  value: string,
-  key: string
-) => unknown;
+export type DeserializeValueFunction = (value: string, key: string) => unknown;
 
-export type DeserializeKeyFunction = (
-  key: string
-) => PropertyKey;
+export type DeserializeKeyFunction = (key: string) => PropertyKey;
 
 export interface Options {
   // Enable parsing nested objects and arrays
   // default: true
-  nested: boolean;
+  nesting: boolean;
 
   // Nesting syntax
   // default: "dot"
@@ -49,7 +44,7 @@ export interface Options {
 const identityFunc = <T>(v: T): T => v;
 
 export const defaultOptions: Options = {
-  nested: true,
+  nesting: true,
   nestingSyntax: 'dot',
   arrayRepeat: false,
   arrayRepeatSyntax: 'repeat',

--- a/src/test/test-cases.ts
+++ b/src/test/test-cases.ts
@@ -138,7 +138,7 @@ export const testCases: TestCase[] = [
   {
     input: 'foo=x&foo=y&foo=z',
     output: {foo: ['x', 'y', 'z']},
-    options: {nested: false, arrayRepeat: true, arrayRepeatSyntax: 'repeat'}
+    options: {nesting: false, arrayRepeat: true, arrayRepeatSyntax: 'repeat'}
   },
   {
     input: 'foo.bar=x&foo.bar=y',
@@ -151,53 +151,53 @@ export const testCases: TestCase[] = [
     input: 'foo[0]=x&foo[1]=y',
     stringifyOutput: 'foo%5B0%5D=x&foo%5B1%5D=y',
     output: {foo: ['x', 'y']},
-    options: {nested: true, nestingSyntax: 'index'}
+    options: {nesting: true, nestingSyntax: 'index'}
   },
   {
     input: 'foo[0]=x&foo[1]=y',
     stringifyOutput: 'foo%5B0%5D=x&foo%5B1%5D=y',
     output: {'foo[0]': 'x', 'foo[1]': 'y'},
-    options: {nested: true, nestingSyntax: 'dot'}
+    options: {nesting: true, nestingSyntax: 'dot'}
   },
   {
     input: 'foo[bar]=x&foo[baz]=y',
     stringifyOutput: 'foo%5Bbar%5D=x&foo%5Bbaz%5D=y',
     output: {foo: {bar: 'x', baz: 'y'}},
-    options: {nested: true, nestingSyntax: 'index'}
+    options: {nesting: true, nestingSyntax: 'index'}
   },
   {
     input: 'foo[bar]=x&foo[baz]=y',
     stringifyOutput: 'foo%5Bbar%5D=x&foo%5Bbaz%5D=y',
     output: {'foo[bar]': 'x', 'foo[baz]': 'y'},
-    options: {nested: true, nestingSyntax: 'dot'}
+    options: {nesting: true, nestingSyntax: 'dot'}
   },
   {
     input: 'foo[bar][baz]=dwa',
     stringifyOutput: 'foo%5Bbar%5D%5Bbaz%5D=dwa',
     output: {foo: {bar: {baz: 'dwa'}}},
-    options: {nested: true, nestingSyntax: 'index'}
+    options: {nesting: true, nestingSyntax: 'index'}
   },
 
   // Nesting syntax: dot
   {
     input: 'foo.0=x&foo.1=y',
     output: {foo: ['x', 'y']},
-    options: {nested: true, nestingSyntax: 'dot'}
+    options: {nesting: true, nestingSyntax: 'dot'}
   },
   {
     input: 'foo.0=x&foo.1=y',
     output: {'foo.0': 'x', 'foo.1': 'y'},
-    options: {nested: true, nestingSyntax: 'index'}
+    options: {nesting: true, nestingSyntax: 'index'}
   },
   {
     input: 'foo.bar=x&foo.baz=y',
     output: {foo: {bar: 'x', baz: 'y'}},
-    options: {nested: true, nestingSyntax: 'dot'}
+    options: {nesting: true, nestingSyntax: 'dot'}
   },
   {
     input: 'foo.bar=x&foo.baz=y',
     output: {'foo.bar': 'x', 'foo.baz': 'y'},
-    options: {nested: true, nestingSyntax: 'index'}
+    options: {nesting: true, nestingSyntax: 'index'}
   },
 
   // Sparse array with nestinh
@@ -205,7 +205,7 @@ export const testCases: TestCase[] = [
     input: 'foo[0]=x&foo[2]=y',
     stringifyOutput: 'foo%5B0%5D=x&foo%5B2%5D=y',
     output: {foo: createSparseArray(['x', undefined, 'y'])},
-    options: {nested: true, nestingSyntax: 'index'}
+    options: {nesting: true, nestingSyntax: 'index'}
   },
 
   // Delimiter: ;
@@ -220,7 +220,7 @@ export const testCases: TestCase[] = [
     input: 'foo[bar]=x',
     stringifyOutput: 'foo%5Bbar%5D=x',
     output: {'foo[bar]': 'x'},
-    options: {nested: false}
+    options: {nesting: false}
   },
 
   // With a key deserializer


### PR DESCRIPTION
To be consistent with `arrayRepeat` vs `arrayRepeatSyntax` etc.