### PR TITLE
feat: switch to esm-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-dev",
   "description": "A small library for parsing and serialisation query strings",
   "main": "lib/main.js",
+  "type": "module",
   "files": [
     "lib",
     "!lib/test"


### PR DESCRIPTION
2.x and beyond will ship as ESM only. 1.x will continue to have
  backported fixes and non-breaking features.