### PR TITLE
perf: follow nested object during parsing

### DIFF
--- a/src/object-util.ts
+++ b/src/object-util.ts
@@ -1,57 +1,32 @@
 import {type Options, defaultOptions} from './shared.js';
 
-export function getDeepValue(obj: unknown, keys: PropertyKey[]): unknown {
-  const keysLength = keys.length;
-  for (let i = 0; i < keysLength; i++) {
-    obj = (obj as Record<PropertyKey, unknown>)[keys[i]];
-    if (!obj) {
-      return obj;
-    }
-  }
-  return obj;
-}
-
 type KeyableObject = Record<PropertyKey, unknown>;
 
-export function setDeepValue(
-  obj: unknown,
-  keys: PropertyKey[],
-  val: unknown
-): void {
-  const len = keys.length;
-  const lastKey = len - 1;
-  let k;
-  let curr = obj as KeyableObject;
-  let currVal;
-  let nextKey;
+function isPrototypeKey(value: unknown) {
+  return (
+    value === '__proto__' || value === 'constructor' || value === 'prototype'
+  );
+}
 
-  for (let i = 0; i < len; i++) {
-    k = keys[i];
-
-    if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
-      break;
-    }
-
-    if (i === lastKey) {
-      curr[k] = val;
-    } else {
-      currVal = curr[k];
-      if (typeof currVal === 'object' && currVal !== null) {
-        curr = currVal as KeyableObject;
-      } else {
-        nextKey = keys[i + 1];
-        if (
-          typeof nextKey === 'string' &&
-          ((nextKey as unknown as number) * 0 !== 0 ||
-            nextKey.indexOf('.') > -1)
-        ) {
-          curr = curr[k] = {};
-        } else {
-          curr = curr[k] = [] as unknown as KeyableObject;
-        }
-      }
-    }
+export function getDeepObject(
+  obj: KeyableObject,
+  lastKey: PropertyKey,
+  key: PropertyKey
+): KeyableObject {
+  const currObj = obj[lastKey] as KeyableObject;
+  if (typeof currObj === 'object' && currObj !== null) {
+    if (isPrototypeKey(lastKey)) return obj;
+    return currObj;
   }
+  // Check if the key is not a number, if it is a number, an array must be used
+  else if (
+    typeof key === 'string' &&
+    ((key as unknown as number) * 0 !== 0 || key.indexOf('.') > -1)
+  ) {
+    if (isPrototypeKey(lastKey)) return obj;
+    return (obj[lastKey] = {});
+  }
+  return (obj[lastKey] = []) as unknown as KeyableObject;
 }
 
 const MAX_DEPTH = 20;

--- a/src/object-util.ts
+++ b/src/object-util.ts
@@ -10,23 +10,23 @@ function isPrototypeKey(value: unknown) {
 
 export function getDeepObject(
   obj: KeyableObject,
-  lastKey: PropertyKey,
-  key: PropertyKey
+  key: PropertyKey,
+  nextKey: PropertyKey
 ): KeyableObject {
-  const currObj = obj[lastKey] as KeyableObject;
+  if (isPrototypeKey(key)) return obj;
+
+  const currObj = obj[key] as KeyableObject;
   if (typeof currObj === 'object' && currObj !== null) {
-    if (isPrototypeKey(lastKey)) return obj;
     return currObj;
   }
   // Check if the key is not a number, if it is a number, an array must be used
   else if (
-    typeof key === 'string' &&
-    ((key as unknown as number) * 0 !== 0 || key.indexOf('.') > -1)
+    typeof nextKey === 'string' &&
+    ((nextKey as unknown as number) * 0 !== 0 || nextKey.indexOf('.') > -1)
   ) {
-    if (isPrototypeKey(lastKey)) return obj;
-    return (obj[lastKey] = {});
+    return (obj[key] = {});
   }
-  return (obj[lastKey] = []) as unknown as KeyableObject;
+  return (obj[key] = []) as unknown as KeyableObject;
 }
 
 const MAX_DEPTH = 20;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,3 +1,4 @@
+import {getDeepObject} from './object-util.js';
 import {
   type Options,
   type DeserializeKeyFunction,
@@ -5,7 +6,6 @@ import {
   defaultOptions
 } from './shared.js';
 import fastDecode from 'fast-decode-uri-component';
-import {getDeepValue, setDeepValue} from './object-util.js';
 
 export type ParsedQuery = Record<PropertyKey, unknown>;
 export type ParseOptions = Partial<Options>;
@@ -81,8 +81,9 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
   let startingIndex = -1;
   let equalityIndex = -1;
   let keySeparatorIndex = -1;
-  let keyPath: PropertyKey[] = [];
-  let lastKeyPathPart: PropertyKey = '';
+  let currentObj = result;
+  let lastKey: PropertyKey | undefined = undefined;
+  let currentKey: PropertyKey = '';
   let keyChunk = '';
   let shouldDecodeKey = false;
   let shouldDecodeValue = false;
@@ -116,12 +117,14 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
           shouldDecodeKey
         );
 
-        lastKeyPathPart = keyDeserializer(keyChunk);
-        keyPath.push(lastKeyPathPart);
+        currentKey = keyDeserializer(keyChunk);
+        if (lastKey !== undefined) {
+          currentObj = getDeepObject(currentObj, lastKey, currentKey);
+        }
       }
 
       // Add key/value pair only if the range size is greater than 1; a.k.a. contains at least "="
-      if (hasBothKeyValuePair || keyPath.length > 0) {
+      if (hasBothKeyValuePair || currentKey !== '') {
         if (hasBothKeyValuePair) {
           value = input.slice(equalityIndex + 1, i);
 
@@ -134,32 +137,17 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
           }
         }
 
-        const newValue = valueDeserializer(value, lastKeyPathPart);
-        const hasNestedKey = nesting && keyPath.length > 1;
-        let currentValue;
-
-        if (hasNestedKey) {
-          currentValue = getDeepValue(result, keyPath);
-        } else {
-          currentValue = result[lastKeyPathPart];
-        }
+        const newValue = valueDeserializer(value, currentKey);
+        const currentValue = currentObj[currentKey];
 
         if (currentValue === undefined || !arrayRepeat) {
-          if (hasNestedKey) {
-            setDeepValue(result, keyPath, newValue);
-          } else {
-            result[lastKeyPathPart] = newValue;
-          }
+          currentObj[currentKey] = newValue;
         } else if (arrayRepeat) {
           // Optimization: value.pop is faster than Array.isArray(value)
           if ((currentValue as unknown[]).pop) {
             (currentValue as unknown[]).push(newValue);
           } else {
-            if (hasNestedKey) {
-              setDeepValue(result, keyPath, [currentValue, newValue]);
-            } else {
-              result[lastKeyPathPart] = [currentValue, newValue];
-            }
+            currentObj[currentKey] = [currentValue, newValue];
           }
         }
       }
@@ -174,8 +162,9 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
       valueHasPlus = false;
       arrayRepeatBracketIndex = -1;
       keySeparatorIndex = i;
-      keyPath = [];
-      lastKeyPathPart = '';
+      currentObj = result;
+      lastKey = undefined;
+      currentKey = '';
     }
     // Check ']'
     else if (c === 93) {
@@ -199,8 +188,11 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
           shouldDecodeKey
         );
 
-        lastKeyPathPart = keyDeserializer(keyChunk);
-        keyPath.push(lastKeyPathPart);
+        currentKey = keyDeserializer(keyChunk);
+        if (lastKey !== undefined) {
+          currentObj = getDeepObject(currentObj, lastKey, currentKey);
+        }
+        lastKey = currentKey;
 
         keySeparatorIndex = i;
         keyHasPlus = false;
@@ -222,8 +214,11 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
           shouldDecodeKey
         );
 
-        lastKeyPathPart = keyDeserializer(keyChunk);
-        keyPath.push(lastKeyPathPart);
+        currentKey = keyDeserializer(keyChunk);
+        if (lastKey !== undefined) {
+          currentObj = getDeepObject(currentObj, lastKey, currentKey);
+        }
+        lastKey = currentKey;
 
         keySeparatorIndex = i;
         keyHasPlus = false;
@@ -246,8 +241,12 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
             shouldDecodeKey
           );
 
-          lastKeyPathPart = keyDeserializer(keyChunk);
-          keyPath.push(lastKeyPathPart);
+          currentKey = keyDeserializer(keyChunk);
+          if (lastKey !== undefined) {
+            currentObj = getDeepObject(currentObj, lastKey, currentKey);
+          }
+          lastKey = currentKey;
+
           keyHasPlus = false;
           shouldDecodeKey = false;
         }

--- a/src/test/object-util_test.ts
+++ b/src/test/object-util_test.ts
@@ -36,11 +36,13 @@ test('getDeepObject', async (t) => {
   });
 
   await t.test('replaces null with new object', () => {
-    assert.deepEqual(getDeepObject({foo: null}, 'foo', ''), {});
+    assert.deepEqual(getDeepObject({foo: null}, 'foo', 'bar'), {});
   });
 
   await t.test('treats decimals as object keys', () => {
-    assert.deepEqual(getDeepObject({}, 'foo', '1.5'), {'1.5': {}});
+    const obj = {};
+    getDeepObject(obj, 'foo', '1.5');
+    assert.deepEqual(obj, {foo: {}});
   });
 });
 

--- a/src/test/object-util_test.ts
+++ b/src/test/object-util_test.ts
@@ -11,10 +11,36 @@ test('getDeepObject', async (t) => {
     assert.deepEqual(getDeepObject({}, 'foo', '1'), []);
   });
 
+  await t.test('array if key is number', () => {
+    assert.deepEqual(getDeepObject({}, 'foo', 5), []);
+  });
+
   await t.test('existing object if value last key already exists', () => {
     assert.deepEqual(getDeepObject({foo: {bar: true}}, 'foo', 'baz'), {
       bar: true
     });
+  });
+
+  const disallowedNames = ['__proto__', 'constructor', 'prototype'];
+
+  for (const name of disallowedNames) {
+    await t.test(`setting disallowed ${name} returns object as-is`, () => {
+      assert.deepEqual(getDeepObject({foo: 'bar'}, name, 'foo'), {foo: 'bar'});
+    });
+  }
+
+  await t.test('can key into existing sub-object', () => {
+    assert.deepEqual(getDeepObject({foo: {bar: 'baz'}}, 'foo', ''), {
+      bar: 'baz'
+    });
+  });
+
+  await t.test('replaces null with new object', () => {
+    assert.deepEqual(getDeepObject({foo: null}, 'foo', ''), {});
+  });
+
+  await t.test('treats decimals as object keys', () => {
+    assert.deepEqual(getDeepObject({}, 'foo', '1.5'), {'1.5': {}});
   });
 });
 

--- a/src/test/object-util_test.ts
+++ b/src/test/object-util_test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict';
-import { test } from 'node:test';
-import { getNestedValues, getDeepObject } from '../object-util.js';
+import {test} from 'node:test';
+import {getNestedValues, getDeepObject} from '../object-util.js';
 
 test('getDeepObject', async (t) => {
   await t.test('object if string key', () => {
@@ -16,7 +16,7 @@ test('getDeepObject', async (t) => {
   });
 
   await t.test('existing object if value last key already exists', () => {
-    assert.deepEqual(getDeepObject({ foo: { bar: true } }, 'foo', 'baz'), {
+    assert.deepEqual(getDeepObject({foo: {bar: true}}, 'foo', 'baz'), {
       bar: true
     });
   });
@@ -25,18 +25,18 @@ test('getDeepObject', async (t) => {
 
   for (const name of disallowedNames) {
     await t.test(`setting disallowed ${name} returns object as-is`, () => {
-      assert.deepEqual(getDeepObject({ foo: 'bar' }, name, 'foo'), { foo: 'bar' });
+      assert.deepEqual(getDeepObject({foo: 'bar'}, name, 'foo'), {foo: 'bar'});
     });
   }
 
   await t.test('can key into existing sub-object', () => {
-    assert.deepEqual(getDeepObject({ foo: { bar: 'baz' } }, 'foo', ''), {
+    assert.deepEqual(getDeepObject({foo: {bar: 'baz'}}, 'foo', ''), {
       bar: 'baz'
     });
   });
 
   await t.test('replaces null with new object', () => {
-    assert.deepEqual(getDeepObject({ foo: null }, 'foo', 'bar'), {});
+    assert.deepEqual(getDeepObject({foo: null}, 'foo', 'bar'), {});
   });
 
   await t.test('treats decimals as object keys', () => {
@@ -46,8 +46,8 @@ test('getDeepObject', async (t) => {
   await t.test('mutates original object', () => {
     const obj = {};
     getDeepObject(obj, 'foo', 'bar');
-    assert.deepEqual(obj, { foo: {} });
-  })
+    assert.deepEqual(obj, {foo: {}});
+  });
 });
 
 test('getNestedValues', async (t) => {
@@ -56,7 +56,7 @@ test('getNestedValues', async (t) => {
       a: 'foo',
       b: 'bar'
     };
-    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
+    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
       ['a', 'foo'],
       ['b', 'bar']
     ]);
@@ -70,7 +70,7 @@ test('getNestedValues', async (t) => {
         }
       }
     };
-    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
+    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
       ['a.b.c', 'foo']
     ]);
   });
@@ -88,7 +88,7 @@ test('getNestedValues', async (t) => {
         d1: 'foo'
       }
     };
-    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
+    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
       ['a', 'foo'],
       ['b.b1.b2', 'foo'],
       ['c', 'foo'],
@@ -103,7 +103,7 @@ test('getNestedValues', async (t) => {
         a2: 'bar'
       }
     };
-    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
+    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
       ['a.a1', 'foo'],
       ['a.a2', 'bar']
     ]);
@@ -113,7 +113,7 @@ test('getNestedValues', async (t) => {
     const obj = {
       a: ['foo', 'bar']
     };
-    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
+    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
       ['a.0', 'foo'],
       ['a.1', 'bar']
     ]);
@@ -127,7 +127,7 @@ test('getNestedValues', async (t) => {
         }
       ]
     };
-    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
+    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
       ['a.0.b', 'foo']
     ]);
   });
@@ -141,7 +141,7 @@ test('getNestedValues', async (t) => {
         }
       }
     };
-    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'index' }), [
+    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'index'}), [
       ['a[a1]', 'foo'],
       ['a[a2][a3]', 'foo']
     ]);
@@ -152,12 +152,12 @@ test('getNestedValues', async (t) => {
       foo: {
         foo1: 'bar',
         foo2: undefined
-      } as { foo1: string; foo2: unknown }
+      } as {foo1: string; foo2: unknown}
     };
     obj.foo.foo2 = obj;
 
     // as long as it doesn't hang forever, we're good
-    assert.ok(getNestedValues(obj, { nestingSyntax: 'dot' }));
+    assert.ok(getNestedValues(obj, {nestingSyntax: 'dot'}));
   });
 
   await t.test('repeated array values (repeat)', () => {
@@ -165,7 +165,7 @@ test('getNestedValues', async (t) => {
       foo: [1, 2]
     };
     assert.deepEqual(
-      getNestedValues(obj, { arrayRepeat: true, arrayRepeatSyntax: 'repeat' }),
+      getNestedValues(obj, {arrayRepeat: true, arrayRepeatSyntax: 'repeat'}),
       [
         ['foo', 1],
         ['foo', 2]
@@ -178,7 +178,7 @@ test('getNestedValues', async (t) => {
       foo: [1, 2]
     };
     assert.deepEqual(
-      getNestedValues(obj, { arrayRepeat: true, arrayRepeatSyntax: 'bracket' }),
+      getNestedValues(obj, {arrayRepeat: true, arrayRepeatSyntax: 'bracket'}),
       [
         ['foo[]', 1],
         ['foo[]', 2]

--- a/src/test/object-util_test.ts
+++ b/src/test/object-util_test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict';
-import {test} from 'node:test';
-import {getNestedValues, getDeepObject} from '../object-util.js';
+import { test } from 'node:test';
+import { getNestedValues, getDeepObject } from '../object-util.js';
 
 test('getDeepObject', async (t) => {
   await t.test('object if string key', () => {
@@ -16,7 +16,7 @@ test('getDeepObject', async (t) => {
   });
 
   await t.test('existing object if value last key already exists', () => {
-    assert.deepEqual(getDeepObject({foo: {bar: true}}, 'foo', 'baz'), {
+    assert.deepEqual(getDeepObject({ foo: { bar: true } }, 'foo', 'baz'), {
       bar: true
     });
   });
@@ -25,25 +25,29 @@ test('getDeepObject', async (t) => {
 
   for (const name of disallowedNames) {
     await t.test(`setting disallowed ${name} returns object as-is`, () => {
-      assert.deepEqual(getDeepObject({foo: 'bar'}, name, 'foo'), {foo: 'bar'});
+      assert.deepEqual(getDeepObject({ foo: 'bar' }, name, 'foo'), { foo: 'bar' });
     });
   }
 
   await t.test('can key into existing sub-object', () => {
-    assert.deepEqual(getDeepObject({foo: {bar: 'baz'}}, 'foo', ''), {
+    assert.deepEqual(getDeepObject({ foo: { bar: 'baz' } }, 'foo', ''), {
       bar: 'baz'
     });
   });
 
   await t.test('replaces null with new object', () => {
-    assert.deepEqual(getDeepObject({foo: null}, 'foo', 'bar'), {});
+    assert.deepEqual(getDeepObject({ foo: null }, 'foo', 'bar'), {});
   });
 
   await t.test('treats decimals as object keys', () => {
-    const obj = {};
-    getDeepObject(obj, 'foo', '1.5');
-    assert.deepEqual(obj, {foo: {}});
+    assert.deepEqual(getDeepObject({}, 'foo', '1.5'), {});
   });
+
+  await t.test('mutates original object', () => {
+    const obj = {};
+    getDeepObject(obj, 'foo', 'bar');
+    assert.deepEqual(obj, { foo: {} });
+  })
 });
 
 test('getNestedValues', async (t) => {
@@ -52,7 +56,7 @@ test('getNestedValues', async (t) => {
       a: 'foo',
       b: 'bar'
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
+    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
       ['a', 'foo'],
       ['b', 'bar']
     ]);
@@ -66,7 +70,7 @@ test('getNestedValues', async (t) => {
         }
       }
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
+    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
       ['a.b.c', 'foo']
     ]);
   });
@@ -84,7 +88,7 @@ test('getNestedValues', async (t) => {
         d1: 'foo'
       }
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
+    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
       ['a', 'foo'],
       ['b.b1.b2', 'foo'],
       ['c', 'foo'],
@@ -99,7 +103,7 @@ test('getNestedValues', async (t) => {
         a2: 'bar'
       }
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
+    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
       ['a.a1', 'foo'],
       ['a.a2', 'bar']
     ]);
@@ -109,7 +113,7 @@ test('getNestedValues', async (t) => {
     const obj = {
       a: ['foo', 'bar']
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
+    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
       ['a.0', 'foo'],
       ['a.1', 'bar']
     ]);
@@ -123,7 +127,7 @@ test('getNestedValues', async (t) => {
         }
       ]
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
+    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'dot' }), [
       ['a.0.b', 'foo']
     ]);
   });
@@ -137,7 +141,7 @@ test('getNestedValues', async (t) => {
         }
       }
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'index'}), [
+    assert.deepEqual(getNestedValues(obj, { nestingSyntax: 'index' }), [
       ['a[a1]', 'foo'],
       ['a[a2][a3]', 'foo']
     ]);
@@ -148,12 +152,12 @@ test('getNestedValues', async (t) => {
       foo: {
         foo1: 'bar',
         foo2: undefined
-      } as {foo1: string; foo2: unknown}
+      } as { foo1: string; foo2: unknown }
     };
     obj.foo.foo2 = obj;
 
     // as long as it doesn't hang forever, we're good
-    assert.ok(getNestedValues(obj, {nestingSyntax: 'dot'}));
+    assert.ok(getNestedValues(obj, { nestingSyntax: 'dot' }));
   });
 
   await t.test('repeated array values (repeat)', () => {
@@ -161,7 +165,7 @@ test('getNestedValues', async (t) => {
       foo: [1, 2]
     };
     assert.deepEqual(
-      getNestedValues(obj, {arrayRepeat: true, arrayRepeatSyntax: 'repeat'}),
+      getNestedValues(obj, { arrayRepeat: true, arrayRepeatSyntax: 'repeat' }),
       [
         ['foo', 1],
         ['foo', 2]
@@ -174,7 +178,7 @@ test('getNestedValues', async (t) => {
       foo: [1, 2]
     };
     assert.deepEqual(
-      getNestedValues(obj, {arrayRepeat: true, arrayRepeatSyntax: 'bracket'}),
+      getNestedValues(obj, { arrayRepeat: true, arrayRepeatSyntax: 'bracket' }),
       [
         ['foo[]', 1],
         ['foo[]', 2]

--- a/src/test/object-util_test.ts
+++ b/src/test/object-util_test.ts
@@ -1,136 +1,19 @@
 import * as assert from 'node:assert/strict';
 import {test} from 'node:test';
-import {getDeepValue, getNestedValues, setDeepValue} from '../object-util.js';
+import {getNestedValues, getDeepObject} from '../object-util.js';
 
-test('getDeepValue', async (t) => {
-  await t.test('retrieves by single key', () => {
-    const obj = {foo: 123};
-    assert.equal(getDeepValue(obj, ['foo']), 123);
+test('getDeepObject', async (t) => {
+  await t.test('object if string key', () => {
+    assert.deepEqual(getDeepObject({}, 'foo', 'bar'), {});
   });
 
-  await t.test('retrieves by deep key', () => {
-    const obj = {
-      a: {
-        b: {
-          c: {
-            d: 303
-          }
-        }
-      }
-    };
-    assert.equal(getDeepValue(obj, ['a', 'b', 'c', 'd']), 303);
+  await t.test('array if key parseable as number', () => {
+    assert.deepEqual(getDeepObject({}, 'foo', '1'), []);
   });
 
-  await t.test('undefined if part of key not found', () => {
-    const obj = {
-      a: {
-        b: {}
-      }
-    };
-    assert.equal(getDeepValue(obj, ['a', 'b', 'c', 'd']), undefined);
-  });
-
-  await t.test('works with non-string keys', () => {
-    const key = Symbol();
-    const obj = {
-      [key]: 808
-    };
-    assert.equal(getDeepValue(obj, [key]), 808);
-  });
-
-  await t.test('returns root object if no keys', () => {
-    const obj = {};
-    assert.equal(getDeepValue(obj, []), obj);
-  });
-
-  await t.test('indexes into non-object values', () => {
-    const obj = {
-      prop: 'foo'
-    };
-    assert.equal(getDeepValue(obj, ['prop', 'length']), 3);
-  });
-});
-
-const disallowedKeys = ['__proto__', 'constructor', 'prototype'];
-
-test('setDeepValue', async (t) => {
-  for (const key of disallowedKeys) {
-    await t.test(`cannot set ${key}`, () => {
-      const obj = {};
-      setDeepValue(obj, [key], 123);
-      assert.deepEqual(obj, {});
-    });
-
-    await t.test('cannot set proto deeply', () => {
-      const obj = {foo: {}};
-      setDeepValue(obj, ['foo', key], 123);
-      assert.deepEqual(obj, {foo: {}});
-    });
-  }
-
-  await t.test('sets top level key', () => {
-    const obj: Record<PropertyKey, unknown> = {};
-    setDeepValue(obj, ['foo'], 303);
-    assert.deepEqual(obj, {foo: 303});
-  });
-
-  await t.test('sets deep key', () => {
-    const obj: Record<PropertyKey, unknown> = {foo: {}};
-    setDeepValue(obj, ['foo', 'bar'], 303);
-    assert.deepEqual(obj, {foo: {bar: 303}});
-  });
-
-  await t.test('replaces null object value with object', () => {
-    const obj: Record<PropertyKey, unknown> = {foo: null};
-    setDeepValue(obj, ['foo', 'bar'], 303);
-    assert.deepEqual(obj, {
-      foo: {
-        bar: 303
-      }
-    });
-  });
-
-  await t.test('replaces null array value with array', () => {
-    const obj: Record<PropertyKey, unknown> = {foo: null};
-    setDeepValue(obj, ['foo', 0], 303);
-    assert.deepEqual(obj, {
-      foo: [303]
-    });
-  });
-
-  await t.test('creates new objects for object values', () => {
-    const obj: Record<PropertyKey, unknown> = {};
-    setDeepValue(obj, ['foo', 'bar'], 303);
-    assert.deepEqual(obj, {
-      foo: {
-        bar: 303
-      }
-    });
-  });
-
-  await t.test('creates new arrays for array values', () => {
-    const obj: Record<PropertyKey, unknown> = {};
-    setDeepValue(obj, ['foo', 0], 303);
-    assert.deepEqual(obj, {
-      foo: [303]
-    });
-  });
-
-  await t.test('creates new arrays with string indices', () => {
-    const obj: Record<PropertyKey, unknown> = {};
-    setDeepValue(obj, ['foo', '0'], 303);
-    assert.deepEqual(obj, {
-      foo: [303]
-    });
-  });
-
-  await t.test('treats decimal strings as regular keys', () => {
-    const obj: Record<PropertyKey, unknown> = {};
-    setDeepValue(obj, ['foo', '10.0'], 303);
-    assert.deepEqual(obj, {
-      foo: {
-        '10.0': 303
-      }
+  await t.test('existing object if value last key already exists', () => {
+    assert.deepEqual(getDeepObject({foo: {bar: true}}, 'foo', 'baz'), {
+      bar: true
     });
   });
 });

--- a/src/test/test-cases.ts
+++ b/src/test/test-cases.ts
@@ -65,6 +65,11 @@ export const testCases: TestCase[] = [
     stringifyOutput: 'foo=&bar=',
     output: {foo: '', bar: ''}
   },
+  {
+    input: '=x',
+    stringifyOutput: '=x',
+    output: {'': 'x'}
+  },
 
   // Encoded keys and values
   {


### PR DESCRIPTION
The current version of picoquery tracks the key path in an array and then processes the key path afterwards. This is bad for performance for two reasons. Firstly pushing to an array is more expensive than just setting a string value and secondly it means the path needs to be processed twice when parsing nested query strings.

This can be improved by tracking the current object whilst parsing. The previous and current key must be tracked in order to know whether to create an array or an object in place of the previous key.

![image](https://github.com/43081j/picoquery/assets/66561610/23e24f82-1177-4de3-869d-60344a475379)
