### PR TITLE
fix: remove dead code for index nested start keys

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -242,9 +242,6 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
           );
 
           currentKey = keyDeserializer(keyChunk);
-          if (lastKey !== undefined) {
-            currentObj = getDeepObject(currentObj, lastKey, currentKey);
-          }
           lastKey = currentKey;
 
           keyHasPlus = false;

--- a/src/test/test-cases.ts
+++ b/src/test/test-cases.ts
@@ -183,6 +183,18 @@ export const testCases: TestCase[] = [
     options: {nesting: true, nestingSyntax: 'index'}
   },
   {
+    input: 'foo[one][two][three]=dwa',
+    stringifyOutput: 'foo%5Bone%5D%5Btwo%5D%5Bthree%5D=dwa',
+    output: {foo: {one: {two: {three: 'dwa'}}}},
+    options: {nesting: true, nestingSyntax: 'index'}
+  },
+  {
+    input: 'foo[one]invalid[two]=dwa',
+    stringifyOutput: 'foo%5Binvalid%5D%5Btwo%5D=dwa',
+    output: {foo: {invalid: {two: 'dwa'}}},
+    options: {nesting: true, nestingSyntax: 'index'}
+  },
+  {
     input: 'foo[bar=trzy',
     stringifyOutput: 'foo%5Bbar%5D=trzy',
     output: {foo: {bar: 'trzy'}},
@@ -203,6 +215,11 @@ export const testCases: TestCase[] = [
   {
     input: 'foo.bar=x&foo.baz=y',
     output: {foo: {bar: 'x', baz: 'y'}},
+    options: {nesting: true, nestingSyntax: 'dot'}
+  },
+  {
+    input: 'foo.bar.x=x&foo.bar.y=y',
+    output: {foo: {bar: {x: 'x', y: 'y'}}},
     options: {nesting: true, nestingSyntax: 'dot'}
   },
   {


### PR DESCRIPTION
When using index nesting, the parse loop visits `[` and computes keys _only if_ we didn't just pass a `]`.

This is to capture the start of such a key. For example, `foo[bar][baz]` would result in the only occurrence of this being `foo[`.

Since a syntactically valid indexed key should only have one of these (at the start), `lastKey` should always be `undefined` at that point. So we can remove the check.

cc @PondWader just one i noticed after merging. if you get a spare 5 mins, could you check i'm making sense here 👀 