### PR TITLE
perf: rework stringify to avoid array alloc

### DIFF
--- a/src/object-util.ts
+++ b/src/object-util.ts
@@ -1,4 +1,5 @@
 import {type Options, defaultOptions} from './shared.js';
+import {encodeString} from './string-util.js';
 
 type KeyableObject = Record<PropertyKey, unknown>;
 
@@ -35,26 +36,50 @@ const strBracketLeft = '[';
 const strBracketRight = ']';
 const strDot = '.';
 
-export type KeyValuePair = [PropertyKey, unknown];
+type Primitive = number | string | boolean;
 
-function walkNestedValues(
+function getAsPrimitive(value: unknown): Primitive {
+  switch (typeof value) {
+    case 'string':
+      // Length check is handled inside encodeString function
+      return encodeString(value);
+    case 'bigint':
+    case 'boolean':
+      return '' + value;
+    case 'number':
+      if (Number.isFinite(value)) {
+        return value < 1e21 ? '' + value : encodeString('' + value);
+      }
+      break;
+  }
+
+  return '';
+}
+
+export function stringifyObject(
   obj: Record<PropertyKey, unknown>,
   options: Partial<Options>,
-  out: KeyValuePair[],
   depth: number = 0,
   parentKey?: string,
   useArrayRepeatKey?: boolean
-): void {
+): string {
   const {
     nestingSyntax = defaultOptions.nestingSyntax,
     arrayRepeat = defaultOptions.arrayRepeat,
     arrayRepeatSyntax = defaultOptions.arrayRepeatSyntax,
-    nesting = defaultOptions.nesting
+    nesting = defaultOptions.nesting,
+    delimiter = defaultOptions.delimiter
   } = options;
+  const strDelimiter =
+    typeof delimiter === 'number' ? String.fromCharCode(delimiter) : delimiter;
 
   if (depth > MAX_DEPTH) {
-    return;
+    return '';
   }
+
+  let result = '';
+  let firstKey = true;
+  let probableArray = false;
 
   for (const key in obj) {
     const value = obj[key];
@@ -77,38 +102,32 @@ function walkNestedValues(
       path = key;
     }
 
-    const probableArray = (value as unknown[]).pop !== undefined;
+    if (!firstKey) {
+      result += strDelimiter;
+    }
 
-    if (
-      typeof value === 'object' &&
-      value !== null &&
-      (nesting || (arrayRepeat && probableArray))
-    ) {
-      walkNestedValues(
-        value as Record<PropertyKey, unknown>,
-        options,
-        out,
-        depth + 1,
-        path,
-        arrayRepeat && probableArray
-      );
+    if (typeof value === 'object' && value !== null) {
+      probableArray = (value as unknown[]).pop !== undefined;
+
+      if (nesting || (arrayRepeat && probableArray)) {
+        result += stringifyObject(
+          value as Record<PropertyKey, unknown>,
+          options,
+          depth + 1,
+          path,
+          arrayRepeat && probableArray
+        );
+      }
     } else {
-      out.push([path, value]);
+      result += encodeString(path);
+      result += '=';
+      result += getAsPrimitive(value);
+    }
+
+    if (firstKey) {
+      firstKey = false;
     }
   }
-}
-
-export function getNestedValues(
-  obj: object,
-  options: Partial<Options>
-): KeyValuePair[] {
-  const result: KeyValuePair[] = [];
-
-  if (obj === null) {
-    return result;
-  }
-
-  walkNestedValues(obj as Record<PropertyKey, unknown>, options, result);
 
   return result;
 }

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,26 +1,5 @@
-import {encodeString} from './string-util.js';
-import {type Options, defaultOptions} from './shared.js';
-import {getNestedValues} from './object-util.js';
-
-type Primitive = number | string | boolean;
-
-function getAsPrimitive(value: unknown): Primitive {
-  switch (typeof value) {
-    case 'string':
-      // Length check is handled inside encodeString function
-      return encodeString(value);
-    case 'bigint':
-    case 'boolean':
-      return '' + value;
-    case 'number':
-      if (Number.isFinite(value)) {
-        return value < 1e21 ? '' + value : encodeString('' + value);
-      }
-      break;
-  }
-
-  return '';
-}
+import {type Options} from './shared.js';
+import {stringifyObject} from './object-util.js';
 
 export type StringifyOptions = Partial<Options>;
 
@@ -30,30 +9,10 @@ export type StringifyOptions = Partial<Options>;
  * @returns {string}
  */
 export function stringify(input: unknown, options?: StringifyOptions): string {
-  let result = '';
-
   if (input === null || typeof input !== 'object') {
-    return result;
+    return '';
   }
 
   const optionsObj = options ?? {};
-  const {delimiter = defaultOptions.delimiter} = optionsObj;
-  const strDelimiter =
-    typeof delimiter === 'number' ? String.fromCharCode(delimiter) : delimiter;
-  const nestedValues = getNestedValues(input, optionsObj);
-  const keyLength = nestedValues.length;
-
-  for (let i = 0; i < keyLength; i++) {
-    const [key, value] = nestedValues[i];
-    const encodedKey = encodeString(String(key)) + '=';
-
-    if (i) {
-      result += strDelimiter;
-    }
-
-    result += encodedKey;
-    result += getAsPrimitive(value);
-  }
-
-  return result;
+  return stringifyObject(input as Record<PropertyKey, unknown>, optionsObj);
 }

--- a/src/test/object-util_test.ts
+++ b/src/test/object-util_test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict';
 import {test} from 'node:test';
-import {getNestedValues, getDeepObject} from '../object-util.js';
+import {stringifyObject, getDeepObject} from '../object-util.js';
 
 test('getDeepObject', async (t) => {
   await t.test('object if string key', () => {
@@ -50,16 +50,13 @@ test('getDeepObject', async (t) => {
   });
 });
 
-test('getNestedValues', async (t) => {
+test('stringifyObject', async (t) => {
   await t.test('shallow values', () => {
     const obj = {
       a: 'foo',
       b: 'bar'
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
-      ['a', 'foo'],
-      ['b', 'bar']
-    ]);
+    assert.equal(stringifyObject(obj, {nestingSyntax: 'dot'}), 'a=foo&b=bar');
   });
 
   await t.test('deep values', () => {
@@ -70,9 +67,7 @@ test('getNestedValues', async (t) => {
         }
       }
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
-      ['a.b.c', 'foo']
-    ]);
+    assert.deepEqual(stringifyObject(obj, {nestingSyntax: 'dot'}), 'a.b.c=foo');
   });
 
   await t.test('mixed deep and shallow values', () => {
@@ -88,12 +83,10 @@ test('getNestedValues', async (t) => {
         d1: 'foo'
       }
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
-      ['a', 'foo'],
-      ['b.b1.b2', 'foo'],
-      ['c', 'foo'],
-      ['d.d1', 'foo']
-    ]);
+    assert.deepEqual(
+      stringifyObject(obj, {nestingSyntax: 'dot'}),
+      'a=foo&b.b1.b2=foo&c=foo&d.d1=foo'
+    );
   });
 
   await t.test('deep values with multiple keys', () => {
@@ -103,20 +96,20 @@ test('getNestedValues', async (t) => {
         a2: 'bar'
       }
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
-      ['a.a1', 'foo'],
-      ['a.a2', 'bar']
-    ]);
+    assert.deepEqual(
+      stringifyObject(obj, {nestingSyntax: 'dot'}),
+      'a.a1=foo&a.a2=bar'
+    );
   });
 
   await t.test('simple array', () => {
     const obj = {
       a: ['foo', 'bar']
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
-      ['a.0', 'foo'],
-      ['a.1', 'bar']
-    ]);
+    assert.deepEqual(
+      stringifyObject(obj, {nestingSyntax: 'dot'}),
+      'a.0=foo&a.1=bar'
+    );
   });
 
   await t.test('array of objects', () => {
@@ -127,9 +120,7 @@ test('getNestedValues', async (t) => {
         }
       ]
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'dot'}), [
-      ['a.0.b', 'foo']
-    ]);
+    assert.deepEqual(stringifyObject(obj, {nestingSyntax: 'dot'}), 'a.0.b=foo');
   });
 
   await t.test('simple index syntax', () => {
@@ -141,10 +132,10 @@ test('getNestedValues', async (t) => {
         }
       }
     };
-    assert.deepEqual(getNestedValues(obj, {nestingSyntax: 'index'}), [
-      ['a[a1]', 'foo'],
-      ['a[a2][a3]', 'foo']
-    ]);
+    assert.deepEqual(
+      stringifyObject(obj, {nestingSyntax: 'index'}),
+      'a%5Ba1%5D=foo&a%5Ba2%5D%5Ba3%5D=foo'
+    );
   });
 
   await t.test('handles circular references', () => {
@@ -157,7 +148,7 @@ test('getNestedValues', async (t) => {
     obj.foo.foo2 = obj;
 
     // as long as it doesn't hang forever, we're good
-    assert.ok(getNestedValues(obj, {nestingSyntax: 'dot'}));
+    assert.ok(stringifyObject(obj, {nestingSyntax: 'dot'}));
   });
 
   await t.test('repeated array values (repeat)', () => {
@@ -165,11 +156,8 @@ test('getNestedValues', async (t) => {
       foo: [1, 2]
     };
     assert.deepEqual(
-      getNestedValues(obj, {arrayRepeat: true, arrayRepeatSyntax: 'repeat'}),
-      [
-        ['foo', 1],
-        ['foo', 2]
-      ]
+      stringifyObject(obj, {arrayRepeat: true, arrayRepeatSyntax: 'repeat'}),
+      'foo=1&foo=2'
     );
   });
 
@@ -178,15 +166,12 @@ test('getNestedValues', async (t) => {
       foo: [1, 2]
     };
     assert.deepEqual(
-      getNestedValues(obj, {arrayRepeat: true, arrayRepeatSyntax: 'bracket'}),
-      [
-        ['foo[]', 1],
-        ['foo[]', 2]
-      ]
+      stringifyObject(obj, {arrayRepeat: true, arrayRepeatSyntax: 'bracket'}),
+      'foo%5B%5D=1&foo%5B%5D=2'
     );
   });
 
-  await t.test('null values result in empty set', () => {
-    assert.deepEqual(getNestedValues(null as unknown as object, {}), []);
+  await t.test('null values result in empty string', () => {
+    assert.deepEqual(stringifyObject({foo: null}, {}), 'foo=');
   });
 });


### PR DESCRIPTION
Changes the stringify logic to build a string up internally rather than producing an array of traversed key/value pairs.

Should result in a little less memory usage and seems to bump the perf up a fair amount in some cases.