### PR TITLE
chore: tweak publish flows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,10 +38,18 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
       - run: npm publish --provenance --access public --tag next
-        if: "github.event.release.prerelease"
+        if: "github.event.release.prerelease && !startsWith(github.ref_name, '1.')"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
       - run: npm publish --provenance --access public
-        if: "!github.event.release.prerelease"
+        if: "!github.event.release.prerelease && !startsWith(github.ref_name, '1.')"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+      - run: npm publish --provenance --access public --tag v1-next
+        if: "github.event.release.prerelease && startsWith(github.ref_name, '1.')"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+      - run: npm publish --provenance --access public --tag v1
+        if: "!github.event.release.prerelease && startsWith(github.ref_name, '1.')"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
Sets the publish flow to do the following:

- `1.*` pre-releases have the `v1-next` tag
- `1.*` releases have the `v1` tag
- all other pre-releases have the `next` tag
- all other releases have the `latest` tag