### PR TITLE
fix: export shared types (#33)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,2 +1,3 @@
 export {parse} from './parse.js';
 export {stringify} from './stringify.js';
+export * from './shared.js';


### PR DESCRIPTION
Exports the shared types so we can get hold of `Options` etc.