### PR TITLE
perf: don't read existing values when parsing without array repeat

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -138,18 +138,18 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
         }
 
         const newValue = valueDeserializer(value, currentKey);
-        const currentValue = currentObj[currentKey];
-
-        if (currentValue === undefined || !arrayRepeat) {
-          currentObj[currentKey] = newValue;
-        } else if (arrayRepeat) {
+        if (arrayRepeat) {
+          const currentValue = currentObj[currentKey];
+          if (currentValue === undefined) {
+            currentObj[currentKey] = newValue;
+          }
           // Optimization: value.pop is faster than Array.isArray(value)
-          if ((currentValue as unknown[]).pop) {
+          else if ((currentValue as unknown[]).pop) {
             (currentValue as unknown[]).push(newValue);
           } else {
             currentObj[currentKey] = [currentValue, newValue];
           }
-        }
+        } else currentObj[currentKey] = newValue;
       }
 
       // Reset reading key value pairs


### PR DESCRIPTION
Reading values from an object is relatively expensive, this PR avoids reading a previous value in the current object unless arrayRepeat is set to true.

![image](https://github.com/43081j/picoquery/assets/66561610/ffe8ef12-4e3c-490e-a20a-12cbe47083fa)
