### PR TITLE
feat: add new js nesting syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Sets which style of nesting syntax should be used. The choices are:
 
 - `dot` (e.g. `foo.bar=baz`)
 - `index` (e.g. `foo[bar]=baz`)
+- `js` (e.g. `foo.bar[0]=baz`, i.e. arrays are indexed and properties are
+dotted)
 
 ### `arrayRepeat`
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -10,7 +10,9 @@ export type NestingSyntax =
   // `foo.bar`
   | 'dot'
   // `foo[bar]`
-  | 'index';
+  | 'index'
+  // `foo.bar[0]`
+  | 'js';
 
 export type DeserializeValueFunction = (
   value: string,

--- a/src/test/object-util_test.ts
+++ b/src/test/object-util_test.ts
@@ -48,6 +48,31 @@ test('getDeepObject', async (t) => {
     getDeepObject(obj, 'foo', 'bar');
     assert.deepEqual(obj, {foo: {}});
   });
+
+  await t.test('creates new object if forceObject=true', () => {
+    const obj = {};
+    getDeepObject(obj, 'foo', '0', true);
+    assert.deepEqual(obj, {
+      foo: {}
+    });
+  });
+
+  await t.test('creates new array if forceArray=true', () => {
+    const obj = {};
+    getDeepObject(obj, 'foo', 'bar', undefined, true);
+    assert.deepEqual(obj, {
+      foo: []
+    });
+  });
+
+  await t.test('handles non-string/non-number keys', () => {
+    const obj = {};
+    const key = Symbol();
+    getDeepObject(obj, 'foo', key);
+    assert.deepEqual(obj, {
+      foo: {}
+    });
+  });
 });
 
 test('stringifyObject', async (t) => {

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -19,4 +19,13 @@ test('parse', async (t) => {
     const result = parse(808 as unknown as string);
     assert.deepEqual({...result}, {});
   });
+
+  await t.test('js nesting dot-syntax always uses a property', () => {
+    const result = parse('foo[bar]=x', {nesting: true, nestingSyntax: 'js'});
+    assert.ok(Array.isArray(result.foo));
+    assert.equal(
+      (result.foo as unknown as Record<PropertyKey, unknown>).bar,
+      'x'
+    );
+  });
 });

--- a/src/test/test-cases.ts
+++ b/src/test/test-cases.ts
@@ -228,6 +228,41 @@ export const testCases: TestCase[] = [
     options: {nesting: true, nestingSyntax: 'index'}
   },
 
+  // Nesting syntax: js
+  {
+    input: 'foo[0]=x&foo[1]=y',
+    stringifyOutput: 'foo%5B0%5D=x&foo%5B1%5D=y',
+    output: {foo: ['x', 'y']},
+    options: {nesting: true, nestingSyntax: 'js'}
+  },
+  {
+    input: 'foo.bar[0]=x&foo.bar[1]=y',
+    stringifyOutput: 'foo.bar%5B0%5D=x&foo.bar%5B1%5D=y',
+    output: {foo: {bar: ['x', 'y']}},
+    options: {nesting: true, nestingSyntax: 'js'}
+  },
+  {
+    input: 'foo.bar[0].baz=x',
+    stringifyOutput: 'foo.bar%5B0%5D.baz=x',
+    output: {foo: {bar: [{baz: 'x'}]}},
+    options: {nesting: true, nestingSyntax: 'js'}
+  },
+  {
+    input: 'foo.bar=x&foo.baz=y',
+    output: {foo: {bar: 'x', baz: 'y'}},
+    options: {nesting: true, nestingSyntax: 'js'}
+  },
+  {
+    input: 'foo.0=x&foo.1=y',
+    output: {foo: {0: 'x', 1: 'y'}},
+    options: {nesting: true, nestingSyntax: 'js'}
+  },
+  {
+    input: 'foo.bar.x=x&foo.bar.y=y',
+    output: {foo: {bar: {x: 'x', y: 'y'}}},
+    options: {nesting: true, nestingSyntax: 'js'}
+  },
+
   // Sparse array with nestinh
   {
     input: 'foo[0]=x&foo[2]=y',


### PR DESCRIPTION
Adds a new syntax type, `js`. With this syntax, arrays use indices and properties use dot-notation.

For example:

```ts
// foo.bar[0]=baz

({
  foo: {
    bar: [
      'baz'
    ]
  }
})
```

Closes #39

doesn't seem to affect benchmarks much, fortunately