### PR TITLE
Omit undefined values in stringify

### DIFF
--- a/src/object-util.ts
+++ b/src/object-util.ts
@@ -74,6 +74,9 @@ export function stringifyObject(
 
   for (const key in obj) {
     const value = obj[key];
+    if (value === undefined) {
+      continue;
+    }
     let path;
     if (parentKey) {
       path = parentKey;

--- a/src/test/object-util_test.ts
+++ b/src/test/object-util_test.ts
@@ -219,4 +219,11 @@ test('stringifyObject', async (t) => {
     });
     assert.equal(result, 'foo=bar');
   });
+  await t.test('ignore undefined values', () => {
+    const obj = {
+      a: undefined,
+      b: 'bar'
+    };
+    assert.equal(stringifyObject(obj, {nestingSyntax: 'dot'}), 'b=bar');
+  });
 });


### PR DESCRIPTION
This PR makes sure undefined values are omitted when using stringify.

Solves: #46

For example:
```ts
const obj = {
      a: undefined,
      b: 'bar'
};
console.log(stringify(obj)) // 'b=bar'
```
