### PR TITLE
feat: allow bracket properties in js syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Sets which style of nesting syntax should be used. The choices are:
 - `dot` (e.g. `foo.bar=baz`)
 - `index` (e.g. `foo[bar]=baz`)
 - `js` (e.g. `foo.bar[0]=baz`, i.e. arrays are indexed and properties are
-dotted)
+dotted or indexed)
 
 ### `arrayRepeat`
 

--- a/bench/parse.js
+++ b/bench/parse.js
@@ -29,6 +29,13 @@ const suites = [
     }
   },
   {
+    name: 'JS nesting',
+    inputs: ['foo.bar.x=303&foo[bar][y]=808'],
+    options: {
+      pico: {nesting: true, nestingSyntax: 'js'}
+    }
+  },
+  {
     name: 'Custom delimiter',
     inputs: ['foo=a;bar=b;baz=c'],
     options: {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -91,7 +91,6 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
   let keyHasPlus = false;
   let valueHasPlus = false;
   let keyIsDot = false;
-  let keyIsIndex = false;
   let hasBothKeyValuePair = false;
   let c = 0;
   let arrayRepeatBracketIndex = -1;
@@ -129,7 +128,7 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
             lastKey,
             currentKey,
             isJsNestingSyntax && keyIsDot,
-            isJsNestingSyntax && keyIsIndex
+            undefined
           );
         }
       }
@@ -176,7 +175,6 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
       keyHasPlus = false;
       valueHasPlus = false;
       keyIsDot = false;
-      keyIsIndex = false;
       arrayRepeatBracketIndex = -1;
       keySeparatorIndex = i;
       currentObj = result;
@@ -212,7 +210,7 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
               lastKey,
               currentKey,
               undefined,
-              isJsNestingSyntax
+              undefined
             );
           }
           lastKey = currentKey;
@@ -221,7 +219,6 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
         }
 
         keySeparatorIndex = i;
-        keyIsIndex = true;
         keyIsDot = false;
       }
     }
@@ -257,7 +254,6 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
         }
 
         keyIsDot = true;
-        keyIsIndex = false;
         keySeparatorIndex = i;
       }
     }
@@ -291,7 +287,6 @@ export function parse(input: string, options?: ParseOptions): ParsedQuery {
           keyHasPlus = false;
           shouldDecodeKey = false;
           keyIsDot = false;
-          keyIsIndex = true;
         }
 
         keySeparatorIndex = i;

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -19,13 +19,4 @@ test('parse', async (t) => {
     const result = parse(808 as unknown as string);
     assert.deepEqual({...result}, {});
   });
-
-  await t.test('js nesting dot-syntax always uses a property', () => {
-    const result = parse('foo[bar]=x', {nesting: true, nestingSyntax: 'js'});
-    assert.ok(Array.isArray(result.foo));
-    assert.equal(
-      (result.foo as unknown as Record<PropertyKey, unknown>).bar,
-      'x'
-    );
-  });
 });

--- a/src/test/test-cases.ts
+++ b/src/test/test-cases.ts
@@ -329,7 +329,24 @@ export const testCases: TestCase[] = [
     options: {nesting: true, nestingSyntax: 'js'}
   },
   {
+    input: 'foo[bar]=x&foo[baz]=y',
+    stringifyOutput: 'foo.bar=x&foo.baz=y',
+    output: {foo: {bar: 'x', baz: 'y'}},
+    options: {nesting: true, nestingSyntax: 'js'}
+  },
+  {
     input: 'foo.bar[]=x',
+    stringifyOutput: 'foo.bar%5B%5D=x',
+    output: {foo: {bar: ['x']}},
+    options: {
+      nesting: true,
+      nestingSyntax: 'js',
+      arrayRepeat: true,
+      arrayRepeatSyntax: 'bracket'
+    }
+  },
+  {
+    input: 'foo[bar][]=x',
     stringifyOutput: 'foo.bar%5B%5D=x',
     output: {foo: {bar: ['x']}},
     options: {


### PR DESCRIPTION
Allows `foo[bar]` in `js` nesting syntax, seeing as it is meant to be js-like after all.

This means the following is valid:

```
foo[bar]=123
// { foo: { bar: 123 } }

foo.bar[baz]=123
// { foo: { bar: { baz: 123 } } }

foo[0][bar].baz=123
// { foo: [ { bar: { baz: 123 } } ] }
```